### PR TITLE
Connect two ci stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,8 @@ deploy-job:
     - pip install hatch
     - hatch config set pypi-token.pypi $PYPI_PASSWORD
     - hatch publish --non-interactive
+  needs:
+    - build-job
   only:
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   except:


### PR DESCRIPTION
Connect build-job and deploy-job.

I'm not sure that this is needed but the current CI config is not working (looks like CI is not triggered when I push a tag) so will try it. Appreciate any feedback.