### PR TITLE
Add keyring install to ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ build-job:
 deploy-job:
   stage: deploy
   script:
-    - pip install hatch
+    - pip install hatch keyrings.alt
     - export HATCH_INDEX_USER=__token__
     - export HATCH_INDEX_AUTH=$PYPI_PASSWORD
     - hatch publish


### PR DESCRIPTION
This change addresses a failure in CI during publishing to pypi that reads:

```
NoKeyringError: No recommended backend was available. Install a recommended 3rd 
party backend package; or, install the keyrings.alt package if you want to use 
the non-recommended backends. See https://pypi.org/project/keyring for details.
```

My understanding is that `keyrings.alt` uses plaintext but this is sufficient for a CI container. There are other OS-dependent "backends" but I'm not sure they will work in CI. If this is not optimal, please leave a comment.