### PR TITLE
Use CI env vars

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,9 +23,7 @@ deploy-job:
   stage: deploy
   script:
     - pip install hatch keyrings.alt
-    - export HATCH_INDEX_USER=__token__
-    - export HATCH_INDEX_AUTH=$PYPI_PASSWORD
-    - hatch publish
+    - hatch publish --no-interactive
   needs:
     - build-job
   only:


### PR DESCRIPTION
Remove HATCH_INDEX_AUTH from ci file, as it's being set directly in GitLab. Also specify no-interactive.