### PR TITLE
Delete tags and rules from oss-scan

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,10 +27,7 @@ build-job:
 
 oss-scan:
   stage: verify
-  rules:
-    - if: '$CI_COMMIT_REF_NAME == "main"'
   extends: .oss-scan
-  tags: []
   when: manual
 
 deploy-job:


### PR DESCRIPTION
Want to run oss-scan manually but haven't been able to yet. This change removes the `tags` attribute which was empty and apparently not necessary, and it removes the rule attribute, which I'm thinking is preventing running it for a pipeline based on a tag.