### PR TITLE
Refactor example, add string representation functions to messages

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -11,7 +11,7 @@ import signalfx  # noqa
 from signalfx.signalflow import messages, SignalFlowClient  # noqa
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         description="SignalFx SignalFlow streaming analytics demo"
     )
@@ -23,59 +23,23 @@ if __name__ == "__main__":
     parser.add_argument("token", help="Your SignalFx API access token")
     parser.add_argument("program", help="SignalFlow program to execute")
     options = parser.parse_args()
-
     client = SignalFlowClient(
         token=options.token,
         endpoint=options.stream_endpoint,
     )
-
     try:
         # Execute the computation and iterate over the message stream
         print("Requesting computation: {0}".format(options.program))
         c = client.execute(options.program)
         print("Waiting for data...")
         for msg in c.stream():
-            if isinstance(msg, messages.DataMessage):
-                print(
-                    "\033[34;1m{0}\033[;0m @{1}: {2}".format(
-                        "data",
-                        msg.logical_timestamp_ms,
-                        ", ".join(
-                            [
-                                "\033[;1m{0}\033[;0m: {1}".format(k, v)
-                                for k, v in msg.data.items()
-                            ]
-                        ),
-                    )
-                )
-            elif isinstance(msg, messages.EventMessage):
-                print(
-                    "\033[35;1m{0}\033[34;1m@\033[;0m @{1}: {2}".format(
-                        "event",
-                        msg.timestamp_ms,
-                        ", ".join(
-                            [
-                                "\033[;1m{0}\033[;0m: {1}".format(k, v)
-                                for k, v in msg.properties.items()
-                            ]
-                        ),
-                    )
-                )
-            elif isinstance(msg, messages.MetadataMessage):
-                print(
-                    "\033[32;1m{0}\033[;0m for \033[;1m{1}\033[;0m:\n  {2}".format(
-                        "metadata",
-                        msg.tsid,
-                        "\n  ".join(
-                            [
-                                "\033[;1m{0}\033[;0m: {1}".format(k, v)
-                                for k, v in msg.properties.items()
-                            ]
-                        ),
-                    )
-                )
+            print(f"Message: {msg}")
     except KeyboardInterrupt:
         print(" Detaching from computation...")
     finally:
         client.close()
     print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/signalfx/signalflow/messages.py
+++ b/src/signalfx/signalflow/messages.py
@@ -66,6 +66,12 @@ class StreamStartMessage(ControlMessage):
     def decode(payload):
         return StreamStartMessage(payload["timestampMs"])
 
+    def __str__(self):
+        return "{0}@{1}".format(
+            "stream_start",
+            self.timestamp_ms
+        )
+
 
 class JobStartMessage(ControlMessage):
     """Message received when the SignalFlow computation has started."""
@@ -82,6 +88,13 @@ class JobStartMessage(ControlMessage):
     @staticmethod
     def decode(payload):
         return JobStartMessage(payload["timestampMs"], payload["handle"])
+
+    def __str__(self):
+        return "{0}@{1}: {2}".format(
+            "job_start",
+            self.timestamp_ms,
+            self._handle
+        )
 
 
 class JobProgressMessage(ControlMessage):
@@ -102,6 +115,13 @@ class JobProgressMessage(ControlMessage):
     def decode(payload):
         return JobProgressMessage(payload["timestampMs"], payload["progress"])
 
+    def __str__(self):
+        return "{0}@{1}: {2}".format(
+            "job_progress",
+            self.timestamp_ms,
+            self.progress
+        )
+
 
 class ChannelAbortMessage(ControlMessage):
     """Message received when the computation aborted before its defined stop
@@ -121,6 +141,13 @@ class ChannelAbortMessage(ControlMessage):
     def decode(payload):
         return ChannelAbortMessage(payload["timestampMs"], payload["abortInfo"])
 
+    def __str__(self):
+        return "{0}@{1}: {2}".format(
+            "channel_abort",
+            self.timestamp_ms,
+            self.abort_info
+        )
+
 
 class EndOfChannelMessage(ControlMessage):
     """Message received when the computation completes normally. No further
@@ -132,6 +159,12 @@ class EndOfChannelMessage(ControlMessage):
     @staticmethod
     def decode(payload):
         return EndOfChannelMessage(payload["timestampMs"])
+
+    def __str__(self):
+        return "{0}@{1}".format(
+            "end_of_channel",
+            self.timestamp_ms,
+        )
 
 
 class InfoMessage(StreamMessage):
@@ -157,6 +190,13 @@ class InfoMessage(StreamMessage):
     @staticmethod
     def decode(payload):
         return InfoMessage(payload["logicalTimestampMs"], payload["message"])
+
+    def __str__(self):
+        return "{0}@{1}: {2}".format(
+            "info",
+            self._logical_timestamp_ms,
+            self.message,
+        )
 
 
 class EventMessage(StreamMessage):
@@ -201,6 +241,19 @@ class EventMessage(StreamMessage):
             payload["properties"],
         )
 
+    def __str__(self):
+        return "{0}@{1}: {2}: {3}".format(
+            "event",
+            self.timestamp_ms,
+            self._metadata,
+            ", ".join(
+                [
+                    "{0}: {1}".format(k, v)
+                    for k, v in self.properties.items()
+                ]
+            ),
+        )
+
 
 class MetadataMessage(StreamMessage):
     """Message containing metadata information about an output metric or event
@@ -225,6 +278,18 @@ class MetadataMessage(StreamMessage):
     def decode(payload):
         return MetadataMessage(payload["tsId"], payload["properties"])
 
+    def __str__(self):
+        return "{0} for {1}:\n  {2}".format(
+            "metadata",
+            self.tsid,
+            "\n  ".join(
+                [
+                    "{0}: {1}".format(k, v)
+                    for k, v in self.properties.items()
+                ]
+            ),
+        )
+
 
 class ExpiredTsIdMessage(StreamMessage):
     """Message informing us that an output timeseries is no longer part of the
@@ -243,6 +308,9 @@ class ExpiredTsIdMessage(StreamMessage):
     @staticmethod
     def decode(payload):
         return ExpiredTsIdMessage(payload["tsId"])
+
+    def __str__(self):
+        return "{0} for {1}".format("expired_tsid", self._tsid)
 
 
 class DataMessage(StreamMessage):
@@ -270,6 +338,18 @@ class DataMessage(StreamMessage):
     def decode(payload):
         return DataMessage(payload["logicalTimestampMs"], payload["data"])
 
+    def __str__(self):
+        return "{0}@{1}: {2}".format(
+            "data",
+            self.logical_timestamp_ms,
+            ", ".join(
+                [
+                    "{0}: {1}".format(k, v)
+                    for k, v in self.data.items()
+                ]
+            ),
+        )
+
 
 class ErrorMessage(StreamMessage):
     """Message received when the computation encounters errors during its
@@ -287,3 +367,7 @@ class ErrorMessage(StreamMessage):
     @staticmethod
     def decode(payload):
         return ErrorMessage(payload["errors"])
+
+    def __str__(self):
+        return "{0}: {1}".format("error", self._errors)
+

--- a/src/signalfx/signalflow/messages.py
+++ b/src/signalfx/signalflow/messages.py
@@ -67,10 +67,7 @@ class StreamStartMessage(ControlMessage):
         return StreamStartMessage(payload["timestampMs"])
 
     def __str__(self):
-        return "{0}@{1}".format(
-            "stream_start",
-            self.timestamp_ms
-        )
+        return "{0}@{1}".format("stream_start", self.timestamp_ms)
 
 
 class JobStartMessage(ControlMessage):
@@ -90,11 +87,7 @@ class JobStartMessage(ControlMessage):
         return JobStartMessage(payload["timestampMs"], payload["handle"])
 
     def __str__(self):
-        return "{0}@{1}: {2}".format(
-            "job_start",
-            self.timestamp_ms,
-            self._handle
-        )
+        return "{0}@{1}: {2}".format("job_start", self.timestamp_ms, self._handle)
 
 
 class JobProgressMessage(ControlMessage):
@@ -116,11 +109,7 @@ class JobProgressMessage(ControlMessage):
         return JobProgressMessage(payload["timestampMs"], payload["progress"])
 
     def __str__(self):
-        return "{0}@{1}: {2}".format(
-            "job_progress",
-            self.timestamp_ms,
-            self.progress
-        )
+        return "{0}@{1}: {2}".format("job_progress", self.timestamp_ms, self.progress)
 
 
 class ChannelAbortMessage(ControlMessage):
@@ -143,9 +132,7 @@ class ChannelAbortMessage(ControlMessage):
 
     def __str__(self):
         return "{0}@{1}: {2}".format(
-            "channel_abort",
-            self.timestamp_ms,
-            self.abort_info
+            "channel_abort", self.timestamp_ms, self.abort_info
         )
 
 
@@ -246,12 +233,7 @@ class EventMessage(StreamMessage):
             "event",
             self.timestamp_ms,
             self._metadata,
-            ", ".join(
-                [
-                    "{0}: {1}".format(k, v)
-                    for k, v in self.properties.items()
-                ]
-            ),
+            ", ".join(["{0}: {1}".format(k, v) for k, v in self.properties.items()]),
         )
 
 
@@ -282,12 +264,7 @@ class MetadataMessage(StreamMessage):
         return "{0} for {1}:\n  {2}".format(
             "metadata",
             self.tsid,
-            "\n  ".join(
-                [
-                    "{0}: {1}".format(k, v)
-                    for k, v in self.properties.items()
-                ]
-            ),
+            "\n  ".join(["{0}: {1}".format(k, v) for k, v in self.properties.items()]),
         )
 
 
@@ -342,12 +319,7 @@ class DataMessage(StreamMessage):
         return "{0}@{1}: {2}".format(
             "data",
             self.logical_timestamp_ms,
-            ", ".join(
-                [
-                    "{0}: {1}".format(k, v)
-                    for k, v in self.data.items()
-                ]
-            ),
+            ", ".join(["{0}: {1}".format(k, v) for k, v in self.data.items()]),
         )
 
 
@@ -370,4 +342,3 @@ class ErrorMessage(StreamMessage):
 
     def __str__(self):
         return "{0}: {1}".format("error", self._errors)
-

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,22 @@
+from signalfx.signalflow.messages import ChannelAbortMessage, DataMessage, EndOfChannelMessage, ErrorMessage, \
+    EventMessage, \
+    ExpiredTsIdMessage, \
+    InfoMessage, \
+    JobProgressMessage, \
+    JobStartMessage, \
+    MetadataMessage, StreamStartMessage
+
+
+def test_stringification():
+    attrs = {"a": 42}
+    assert str(StreamStartMessage(1234)) == "stream_start@1234"
+    assert str(JobStartMessage(1234, "myhandle")) == "job_start@1234: myhandle"
+    assert str(JobProgressMessage(1234, "myprogress")) == "job_progress@1234: myprogress"
+    assert str(ChannelAbortMessage(1234, "myabortinfo")) == "channel_abort@1234: myabortinfo"
+    assert str(EndOfChannelMessage(1234)) == "end_of_channel@1234"
+    assert str(InfoMessage(1234, "mymessage")) == "info@1234: mymessage"
+    assert str(EventMessage("tsid1234", 1234, "mymetadata", attrs)) == "event@1234: mymetadata: a: 42"
+    assert str(MetadataMessage("tsid1234", attrs)).startswith("metadata for tsid1234")
+    assert str(ExpiredTsIdMessage("tsid1234")) == "expired_tsid for tsid1234"
+    assert str(DataMessage(1234, [{"tsId": "tsid1234", "value": "myvalue"}])) == "data@1234: tsid1234: myvalue"
+    assert str(ErrorMessage("myerrors")) == "error: myerrors"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,22 +1,39 @@
-from signalfx.signalflow.messages import ChannelAbortMessage, DataMessage, EndOfChannelMessage, ErrorMessage, \
-    EventMessage, \
-    ExpiredTsIdMessage, \
-    InfoMessage, \
-    JobProgressMessage, \
-    JobStartMessage, \
-    MetadataMessage, StreamStartMessage
+from signalfx.signalflow.messages import (
+    ChannelAbortMessage,
+    DataMessage,
+    EndOfChannelMessage,
+    ErrorMessage,
+    EventMessage,
+    ExpiredTsIdMessage,
+    InfoMessage,
+    JobProgressMessage,
+    JobStartMessage,
+    MetadataMessage,
+    StreamStartMessage,
+)
 
 
 def test_stringification():
     attrs = {"a": 42}
     assert str(StreamStartMessage(1234)) == "stream_start@1234"
     assert str(JobStartMessage(1234, "myhandle")) == "job_start@1234: myhandle"
-    assert str(JobProgressMessage(1234, "myprogress")) == "job_progress@1234: myprogress"
-    assert str(ChannelAbortMessage(1234, "myabortinfo")) == "channel_abort@1234: myabortinfo"
+    assert (
+        str(JobProgressMessage(1234, "myprogress")) == "job_progress@1234: myprogress"
+    )
+    assert (
+        str(ChannelAbortMessage(1234, "myabortinfo"))
+        == "channel_abort@1234: myabortinfo"
+    )
     assert str(EndOfChannelMessage(1234)) == "end_of_channel@1234"
     assert str(InfoMessage(1234, "mymessage")) == "info@1234: mymessage"
-    assert str(EventMessage("tsid1234", 1234, "mymetadata", attrs)) == "event@1234: mymetadata: a: 42"
+    assert (
+        str(EventMessage("tsid1234", 1234, "mymetadata", attrs))
+        == "event@1234: mymetadata: a: 42"
+    )
     assert str(MetadataMessage("tsid1234", attrs)).startswith("metadata for tsid1234")
     assert str(ExpiredTsIdMessage("tsid1234")) == "expired_tsid for tsid1234"
-    assert str(DataMessage(1234, [{"tsId": "tsid1234", "value": "myvalue"}])) == "data@1234: tsid1234: myvalue"
+    assert (
+        str(DataMessage(1234, [{"tsId": "tsid1234", "value": "myvalue"}]))
+        == "data@1234: tsid1234: myvalue"
+    )
     assert str(ErrorMessage("myerrors")) == "error: myerrors"


### PR DESCRIPTION
This change aims to make the basic example simpler by moving the string representation code to the corresponding message classes.