### PR TITLE
VULN: bump protobuf max version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "certifi",
-  "protobuf>=3.18.3,<4.21.0",
+  "protobuf>=3.18.3,<4.25.8",
   "pyformance>=0.3.1",
   "requests>=2.32.0",
   "sseclient-py>=1.4",


### PR DESCRIPTION
Bumps protobuf version to resolve vulnerability outlined in CVE-2025-4565

Fixes: https://github.com/signalfx/signalflow-client-python/issues/21