### PR TITLE
Update protobuf to be at least 4.25.8 to patch VULN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "certifi",
-  "protobuf>=3.18.3,<4.25.8",
+  "protobuf>=3.18.3,<=4.25.8",
   "pyformance>=0.3.1",
   "sseclient-py>=1.4",
   "urllib3>=1.26.19",


### PR DESCRIPTION
There is a vulnerability in protobuf@4.25.7 https://security.snyk.io/vuln/SNYK-PYTHON-PROTOBUF-10364902

It's recommended to upgrade to at least 4.25.8