### PR TITLE
Remove unused protobuf and pyformance dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,6 @@ classifiers = [
 ]
 dependencies = [
   "certifi",
-  "protobuf>=4.25.8,<5.0.0",
-  "pyformance>=0.3.1",
   "sseclient-py>=1.4",
   "urllib3>=2.5.0",
   "six>=1.6.0",


### PR DESCRIPTION
Removes protobuf which was not imported anywhere in the codebase, and pyformance which was also unused. Both were legacy dependencies from the original signalfx-python codebase that are not needed for signalflow client. Manually tested against SFx backend. Addresses #34.